### PR TITLE
Fix typo in 'SWORD API' section header

### DIFF
--- a/docs/spec/base/SUMMARY.md
+++ b/docs/spec/base/SUMMARY.md
@@ -109,7 +109,7 @@
 * [ADMIN-10-1: Resource List 277](./admin/ADMIN_10_1.md)
 * [ADMIN-10-2: Change List 283](./admin/ADMIN_10_2.md)
 * [ADMIN-10-3: Resync 291](./admin/ADMIN_10_3.md)
-### 11 SWQRD API
+### 11 SWORD API
 * [ADMIN-16-1: TSV/XML](admin/ADMIN_16_1.md)
 * [ADMIN-16-2: JSON-LD](admin/ADMIN_16_2.md)
 ### レコード管理 296


### PR DESCRIPTION
@mhaya 
突然失礼いたします。
明らかな誤りがあるかと思いまして、develop_v2.0.0向けにpull requestを提出いたします。
問題なければ取り込んでいただけますと幸いです。